### PR TITLE
gamipress_award_achievement_to_user hooks

### DIFF
--- a/includes/functions/achievements.php
+++ b/includes/functions/achievements.php
@@ -1339,19 +1339,19 @@ add_filter( 'post_updated_messages', 'gamipress_achievement_type_update_messages
  *
  * @since   1.0.0
  * @updated 1.4.7 Added $trigger parameter
+ * @udated tambaqui fork Added $log_meta parameter
  *
  * @param int       $user_id        The user ID
  * @param int       $achievement_id The associated achievement ID
  * @param int       $admin_id       An admin ID (if admin-awarded)
  * @param string    $trigger        The trigger that fires this function
+ * @param array    $log_meta       Log meta
  */
-function gamipress_log_user_achievement_award( $user_id, $achievement_id, $admin_id = 0, $trigger = '' ) {
+function gamipress_log_user_achievement_award( $user_id, $achievement_id, $admin_id = 0, $trigger = '', $log_meta = array() ) {
 
     $post_type = gamipress_get_post_type( $achievement_id );
 
-	$log_meta = array(
-		'achievement_id' => $achievement_id,
-	);
+	$log_meta['achievement_id'] = $achievement_id;
 
 	$access = 'public';
 

--- a/includes/rules-engine.php
+++ b/includes/rules-engine.php
@@ -1236,6 +1236,7 @@ function gamipress_get_achievement_limit_timestamp( $achievement_id = 0 ) {
  * Award an achievement to the user
  *
  * @since  1.0.0
+ * @udated tambaqui fork Added gamipress_award_achievement_object and gamipress_award_achievement_log_meta_data hooks
  *
  * @param  int 	    $achievement_id The given achievement ID to award
  * @param  int 	    $user_id        The given user's ID
@@ -1268,11 +1269,34 @@ function gamipress_award_achievement_to_user( $achievement_id = 0, $user_id = 0,
 	// Setup our achievement
 	$achievement = gamipress_build_achievement_object( $achievement_id );
 
+    /**
+     * Available filter to customize achievement object  with latest event triggered args
+     * 
+     * @param  false|object 	$achievement    The given achievement object
+     * @param  int 	            $user_id        The given user's ID
+     * @param  string 	        $trigger    	The trigger
+     * @param  int 	            $site_id        The triggered site id
+     * @param  array 	        $args           The triggered args
+     */
+    $achievement = apply_filters( 'gamipress_award_achievement_object', $achievement, $user_id, $trigger, $site_id, $args );
+
 	// Update user's earned achievements
 	gamipress_update_user_achievements( array( 'user_id' => $user_id, 'new_achievements' => array( $achievement ) ) );
 
 	// Log the earning of the award
-	gamipress_log_user_achievement_award( $user_id, $achievement_id, $admin_id, $trigger );
+    $log_meta = array();
+    /**
+     * Available filter to insert custom achievement award log meta data
+     * 
+     * @param  array 	$log_meta
+     * @param  int 	    $user_id        The given user's ID
+     * @param  int 	    $achievement_id The given achievement ID to award
+     * @param  string 	$trigger    	The trigger
+     * @param  int 	    $site_id        The triggered site id
+     * @param  array 	$args           The triggered args
+     */
+    $log_meta = apply_filters( 'gamipress_award_achievement_log_meta_data', $log_meta, $user_id, $achievement_id, $trigger, $site_id, $args );
+    gamipress_log_user_achievement_award( $user_id, $achievement_id, $admin_id, $trigger, $log_meta );
 
 	// Available hook for unlocking any achievement of this achievement type
 	do_action( 'gamipress_unlock_' . $achievement->post_type, $user_id, $achievement_id, $trigger, $site_id, $args );


### PR DESCRIPTION
Added `gamipress_award_achievement_object` and `gamipress_award_achievement_log_meta_data` hooks to `gamipress_award_achievement_to_user`, for overwrite acheivement object and award achievement log meta with custom triggered  event args.

The purpose of these hooks is to be able to override the achievement earning and log dates, to allow processing events external to gamipress with dates prior to the current date.

NOTE: for a correct count of occurrences in triggers with repetitions and time limits, it will be necessary to additionally use other gamipress hooks (`gamipress_insert_log`, `gamipress_get_achievement_limit_timestamp`, `gamipress_award_achievement`, `gamipress_update_user_rank`, etc.) to count from the date the event occurred and not from the current date, in addition to overwriting the achievement dates of events recursively launched internally by gamipress and that do not receive the parameters of the custom event that triggered the firing of these additional events.

